### PR TITLE
default formatters should use 2 decimals for numbers

### DIFF
--- a/containers/i18n/formatters/de.js
+++ b/containers/i18n/formatters/de.js
@@ -3,7 +3,7 @@ export default
     datePattern: 'dd.MM.yyyy',
     dateTimePattern: 'dd.MM.yyyy HH:mm:ss',
     integerPattern: '#,##0',
-    numberPattern: '#.##0,00#######',
+    numberPattern: '#.##0,00',
     numberDecimalSeparator: ',',
     numberGroupingSeparator: '.',
     numberGroupingSeparatorUse: true,

--- a/containers/i18n/formatters/en.js
+++ b/containers/i18n/formatters/en.js
@@ -3,7 +3,7 @@ export default
     datePattern: 'dd/MM/yyyy',
     dateTimePattern: 'dd/MM/yyyy HH:mm:ss',
     integerPattern: '#.##0',
-    numberPattern: '#,##0.00#######',
+    numberPattern: '#,##0.00',
     numberDecimalSeparator: '.',
     numberGroupingSeparator: ',',
     numberGroupingSeparatorUse: true,


### PR DESCRIPTION
I believe that a default formatter for numbers should have 2 decimals.
If more are needed, then this should be handled in the place where it is needed.