### PR TITLE
GENESIS-166 Merge translations only with existing languages, use en as fallback

### DIFF
--- a/components/MainMenu/MainMenu.react.js
+++ b/components/MainMenu/MainMenu.react.js
@@ -194,11 +194,12 @@ class MainMenu extends ConditionalRenderComponent
         const { roles } = userData;
 
         const userLocaleItems = navItems.businessPartner[locale] || [];
+        const userItems = this.recursiveMergeNavItems(navItems.businessPartner['en'], userLocaleItems);
         let adminItems = []
         if(roles && roles.indexOf('admin') > -1)
             adminItems = navItems.admin[locale] || navItems.admin['en'];
 
-        const items = this.recursiveMergeNavItems(navItems.businessPartner['en'], userLocaleItems, adminItems);
+        const items = this.recursiveMergeNavItems(userItems, adminItems);
         return items.filter(item => !item.environments || item.environments.includes(environment));
     }
 

--- a/components/MainMenu/MainMenu.react.js
+++ b/components/MainMenu/MainMenu.react.js
@@ -193,7 +193,7 @@ class MainMenu extends ConditionalRenderComponent
         const { businesspartner, supplierid, customerid, roles } = this.context.userData;
         const { locale, environment } = this.context;
 
-        let items = this.recursiveMergeNavItems(navItems.businessPartner['en'], navItems.businessPartner[locale]);
+        let items = navItems.businessPartner[locale] ? this.recursiveMergeNavItems(navItems.businessPartner['en'], navItems.businessPartner[locale]) : navItems.businessPartner['en'];
 
         if(roles && roles.indexOf('admin') > -1)
             items = this.recursiveMergeNavItems(items, navItems.admin[locale] || navItems.admin['en'])

--- a/components/MainMenu/MainMenu.react.js
+++ b/components/MainMenu/MainMenu.react.js
@@ -57,7 +57,7 @@ class MainMenu extends ConditionalRenderComponent
             serviceName: 'business-partner',
             moduleName: 'business-partner-autocomplete',
             jsFileName: 'business-partner-autocomplete-bundle',
-            onError : () => this.BusinessPartnerDropdown = null 
+            onError : () => this.BusinessPartnerDropdown = null
         });
 
         this.CustomerDropdown = context.loadComponent({ serviceName : 'customer', moduleName : 'customer-autocomplete', jsFileName : 'autocomplete-bundle', onError : () => this.CustomerDropdown = null });
@@ -190,14 +190,15 @@ class MainMenu extends ConditionalRenderComponent
 
     getNavItems()
     {
-        const { businesspartner, supplierid, customerid, roles } = this.context.userData;
-        const { locale, environment } = this.context;
+        const { locale, environment, userData } = this.context;
+        const { roles } = userData;
 
-        let items = navItems.businessPartner[locale] ? this.recursiveMergeNavItems(navItems.businessPartner['en'], navItems.businessPartner[locale]) : navItems.businessPartner['en'];
-
+        const userLocaleItems = navItems.businessPartner[locale] || [];
+        let adminItems = []
         if(roles && roles.indexOf('admin') > -1)
-            items = this.recursiveMergeNavItems(items, navItems.admin[locale] || navItems.admin['en'])
+            adminItems = navItems.admin[locale] || navItems.admin['en'];
 
+        const items = this.recursiveMergeNavItems(navItems.businessPartner['en'], userLocaleItems, adminItems);
         return items.filter(item => !item.environments || item.environments.includes(environment));
     }
 

--- a/components/MainMenu/MainMenu.react.js
+++ b/components/MainMenu/MainMenu.react.js
@@ -193,11 +193,12 @@ class MainMenu extends ConditionalRenderComponent
         const { locale, environment, userData } = this.context;
         const { roles } = userData;
 
-        const userLocaleItems = navItems.businessPartner[locale] || [];
+        const userLocaleItems = navItems.businessPartner[locale];
         const userItems = this.recursiveMergeNavItems(navItems.businessPartner['en'], userLocaleItems);
-        let adminItems = []
-        if(roles && roles.indexOf('admin') > -1)
+        let adminItems = [];
+        if(roles && roles.indexOf('admin') > -1) {
             adminItems = navItems.admin[locale] || navItems.admin['en'];
+        }
 
         const items = this.recursiveMergeNavItems(userItems, adminItems);
         return items.filter(item => !item.environments || item.environments.includes(environment));
@@ -206,31 +207,37 @@ class MainMenu extends ConditionalRenderComponent
     recursiveMergeNavItems(items, overlays)
     {
         const results = [ ];
+        const hasValues = arr => Array.isArray(arr) && arr.length >= 1;
 
-        items.forEach(item =>
-        {
-            const overlay = overlays.find(overlay => overlay.key === item.key);
-
-            if(overlay)
+        if (hasValues(items)) {
+            items.forEach(item =>
             {
-                const overlayCopy = Object.assign({ }, overlay);
-                overlayCopy.children = this.recursiveMergeNavItems(item.children || [ ], overlay.children || [ ])
+                const overlay = overlays.find(overlay => overlay.key === item.key);
 
-                results.push(overlayCopy);
-            }
-            else
+                if(overlay)
+                {
+                    const overlayCopy = { ...overlay };
+                    overlayCopy.children = this.recursiveMergeNavItems(item.children, overlay.children)
+
+                    results.push(overlayCopy);
+                }
+                else
+                {
+                    results.push(item);
+                }
+            });
+        }
+
+        if (hasValues(overlays)) {
+            overlays.forEach(overlay =>
             {
-                results.push(item);
-            }
-        });
+                const found = items.reduce((all, item) => all || item.key === overlay.key, false);
 
-        overlays.forEach(overlay =>
-        {
-            const found = items.reduce((all, item) => all || item.key === overlay.key, false);
-
-            if(!found)
-                results.push(overlay);
-        });
+                if(!found) {
+                    results.push(overlay);
+                }
+            });
+        }
 
         return results;
     }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -274,3 +274,33 @@ services:
     labels:
       SERVICE_IGNORE: 'true'  # Do not add any of Consul's services to Consul's service discovery registry.
     command: [agent, '-server', '-ui', '-bootstrap', '-client=0.0.0.0']
+
+  zoo1:
+      image: 'zookeeper:3.4.14'
+      restart: always
+      hostname: zoo1
+      ports:
+          - 2181:2181
+      environment:
+          ZOO_MY_ID: 1
+          ZOO_SERVERS: server.1=0.0.0.0:2888:3888
+      depends_on:
+          - acl
+
+  kafka1:
+      image: wurstmeister/kafka:latest
+      # image: wurstmeister/kafka:2.12-2.5.0
+      ports:
+          - '9092:9092'
+      environment:
+          KAFKA_BROKER_ID: 1
+          # KAFKA_AUTO_CREATE_TOPICS_ENABLE: 'false'
+          KAFKA_NUM_PARTITIONS: 10
+          KAFKA_DEFAULT_REPLICATION_FACTOR: 1
+          KAFKA_PORT: 9092
+          KAFKA_ADVERTISED_HOST_NAME: 'kafka1'
+          KAFKA_LISTENERS: 'PLAINTEXT://:9092'
+          KAFKA_ADVERTISED_LISTENERS: 'PLAINTEXT://kafka1:9092'
+          KAFKA_ZOOKEEPER_CONNECT: zoo1:2181
+      depends_on:
+          - zoo1


### PR DESCRIPTION
Adjust the Menu item language handling.

## Current behavior

When the user.userProfile -> languageId attribute includes a non supported value, the MainMenu breaks and it renders a blank page.

## Expected behavior

When there user's profile includes a non-supported languageId, ie. norwegian("no") or danish("da") , it should load the Menu items in English.

![image](https://user-images.githubusercontent.com/5347552/100238942-13fa3600-2f31-11eb-9aa8-9c801ff85e02.png)

For the changes to take effect. The BNP service has to be updated. This might also affect other services that implements the menu from this library.

## Link

Jira [GENESIS-166](https://opuscapita.atlassian.net/browse/GENESIS-166) 