### PR TITLE
MEP-1388: restored import logs and added standard import

### DIFF
--- a/components/MainMenu/data/navItems/admin.js
+++ b/components/MainMenu/data/navItems/admin.js
@@ -72,6 +72,16 @@ export default
             "key": "reporting",
             "label": "Reporting",
             "link": "/reporting/config"
+        },
+        {
+            "key": "importlogs",
+            "label": "Import Logs",
+            "link": "/bnp/routing/importlogs"
+        },
+        {
+            "key": "standardimport",
+            "label": "Standard Import",
+            "link": "/bnp/routing/import/standard"
         }]
     }],
 
@@ -147,6 +157,16 @@ export default
             "key": "reporting",
             "label": "Reporting",
             "link": "/reporting/config"
+        },
+        {
+            "key": "importlogs",
+            "label": "Import Logs",
+            "link": "/bnp/routing/importlogs"
+        },
+        {
+            "key": "standardimport",
+            "label": "Standard Import",
+            "link": "/bnp/routing/import/standard"
         }]
     }]
 }


### PR DESCRIPTION
These menu entries are linked to:
- Standard Import: https://github.com/OpusCapita/bnp/pull/279
- Import Logs: https://github.com/OpusCapita/bnp/pull/267